### PR TITLE
Fixed middleware classes.

### DIFF
--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -1,4 +1,5 @@
 from django.db.models import signals
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import curry
 
 from audit_log import registration, settings
@@ -23,7 +24,7 @@ def _enable_audit_log_managers(instance):
             pass
 
 
-class UserLoggingMiddleware(object):
+class UserLoggingMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if settings.DISABLE_AUDIT_LOG:
             return
@@ -87,7 +88,7 @@ class UserLoggingMiddleware(object):
 
 
 
-class JWTAuthMiddleware(object):
+class JWTAuthMiddleware(MiddlewareMixin):
     """
     Convenience middleware for users of django-rest-framework-jwt.
     Fixes issue https://github.com/GetBlimp/django-rest-framework-jwt/issues/45


### PR DESCRIPTION
According to this links, middleware classes must extend `django.utils.deprecation.MiddlewareMixin` instead of `object` to avoid compatibility issues between `MIDDLEWARE` and `MIDDLEWARE_CLASSES` configurations:

- https://stackoverflow.com/a/41634798
- https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware

This PR includes changes that allow middleware classes to be configured under `MIDDLEWARE`.

There's a deprecation warning when using `MIDDLEWARE_CLASSES':

> ?: (1_10.W001) The MIDDLEWARE_CLASSES setting is deprecated in Django 1.10 and the MIDDLEWARE setting takes precedence. Since you've set MIDDLEWARE, the value of MIDDLEW
ARE_CLASSES is ignored.

